### PR TITLE
Fixing no error (wild exit without message) when port already in use

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func (s *service) start() error {
 	listener, err := net.Listen("tcp", s.config.Listen)
 
 	if err != nil {
-		return err
+		panic(err)
 	}
 
 	return srv.Serve(listener)


### PR DESCRIPTION
Similar problem is discribing here https://github.com/golang/go/issues/11715